### PR TITLE
example-itim: Add compile flags to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 PROGRAM ?= example-itim
 
 $(PROGRAM): $(wildcard *.c) $(wildcard *.h) $(wildcard *.S)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(filter %.c %.S,$^) $(LOADLIBES) $(LDLIBS) -o $@
 
 clean:
 	rm -f $(PROGRAM) $(PROGRAM).hex


### PR DESCRIPTION
I was trying to build example-itim in a different environment and found it didn't succeed.
By looking at other freedom-e-sdk example Makefiles I saw that many others set CC flags.

I don't quite know _why_ I need this, I hope it's still ok though